### PR TITLE
Reduce jar size by setting scope of lombok and jetbrains annotations to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,13 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>RELEASE</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>RELEASE</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Reduce jar size by setting scope of lombok and jetbrains annotations to provided